### PR TITLE
env vars are not available in cron jobs

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /tmp/mongodump_env
+
 DATE=$(date +%Y%m%d_%H%M%S)
 FILE="/backup/backup-$DATE.tar.gz"
 

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+env > /tmp/mongodump_env
+
 CRON_SCHEDULE=${CRON_SCHEDULE:-0 1 * * *}
 
 echo "$CRON_SCHEDULE /backup.sh" | crontab -


### PR DESCRIPTION
When I run this container, the `backup.sh` script does not get the environment variables set for it and thus fails to work properly.

This PR changes the start script to write the current environment variables for the docker container to `/tmp/mongodump_env`, then when the backup script runs in the cron context it can source the variables to work correctly.
