### PR TITLE
Using last version of mongo to avoid assertion: 17369

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN chmod +x /backup.sh
 ADD start.sh /start.sh
 RUN chmod +x /start.sh
 
+ADD crontab /crontab
+
 VOLUME /backup
 
 ENTRYPOINT ["/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN chmod +x /backup.sh
 ADD start.sh /start.sh
 RUN chmod +x /start.sh
 
+RUN touch /var/log/cron.log
+
 ADD crontab /crontab
 
 VOLUME /backup

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:2.6
+FROM mongo
 MAINTAINER Ilya Stepanov <dev@ilyastepanov.com>
 
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ ea3a814c3720        campus2020portal_web:latest   "node app.js"          6 days 
 $ ./install-backup.sh campus2020portal_mongo_1
 ```
 This will run a docker container with cron job installed inside, which will backup mongodb once a day at 1.00 A.M. and save the output to /var/backups/mongodb as a .tar.gz archive. When you run docker via remote access (i.e. access remote docker host), the data will be saved on remote machine!
+
 For configuration options, please, take a look inside the scripts. Crontab schedule is available in crontab file and `0 1 * * *` by default.
 
 To run backup once you can use the following script:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 docker-mongodump
 ================
 
-Docker image with mongodump running as a cron task
+This is a fork of https://github.com/istepanov/docker-mongodump -- Docker image with mongodump running as a cron task. I added scripts to automatize installation for a backup docker container.
 
 ### How To Use
 First you have to build docker image from the repository:

--- a/README.md
+++ b/README.md
@@ -3,19 +3,21 @@ docker-mongodump
 
 Docker image with mongodump running as a cron task
 
-### Usage
+### How To Use
+First you have to build docker image from the repository:
+```docker build -t istepanov/mongodump .```
+After that you can install backup job for your mongodb docker container as follows (basically provide container name as an argument to install-backup.sh script):
+```
+$ docker ps
+CONTAINER ID        IMAGE                         COMMAND                CREATED             STATUS              PORTS                    NAMES
+ea3a814c3720        campus2020portal_web:latest   "node app.js"          6 days ago          Up 5 days           0.0.0.0:8080->8080/tcp   campus2020portal_web_1     
+39cae58c3dc8        mongo:latest                  "/entrypoint.sh mong   4 weeks ago         Up 5 days           27017/tcp                campus2020portal_mongo_1
+$ ./install-backup.sh campus2020portal_mongo_1
+```
+This will run a docker container with cron job installed inside, which will backup mongodb once a day at 1.00 A.M. and save the output to /var/backups/mongodb as a .tar.gz archive. When you run docker via remote access (i.e. access remote docker host), the data will be saved on remote machine!
+For configuration options, please, take a look inside the scripts. Crontab schedule is available in crontab file and `0 1 * * *` by default.
 
-Attach a target mongo container to this container and mount a volume to container's `/data` folder. Backups will appear in this volume. Optionally set up cron job schedule (default is `0 1 * * *` - runs every day at 1:00 am).
-
-	docker run -d \
-		-v /path/to/target/folder:/backup  # where to put backups
-		-e 'CRON_SCHEDULE=0 1 * * *'       # cron job schedule
-		--link my-mongo-container:mongo	   # linked container with running mongo
-		istepanov/mongodump
-
-To run backup once without cron job, add `no-cron` parameter:
-
-	docker run --rm \
-		-v /path/to/target/folder:/backup  # where to put backups
-		--link my-mongo-container:mongo	   # linked container with running mongo
-		istepanov/mongodump no-cron
+To run backup once you can use the following script:
+```
+$ ./run-backup.sh campus2020portal_mongo_1
+```

--- a/crontab
+++ b/crontab
@@ -1,0 +1,2 @@
+* * * * * root /backup.sh
+# An empty line is required at the end of this file for a valid cron file.

--- a/crontab
+++ b/crontab
@@ -1,2 +1,2 @@
-* * * * * root /backup.sh
+0 1 * * * root /backup.sh >> /var/log/cron.log 2>&1
 # An empty line is required at the end of this file for a valid cron file.

--- a/install-backup.sh
+++ b/install-backup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+BACKUP_DIR=/var/backups/mongodb
+CONTAINER_NAME=$1
+DOCKER_NAME="istepanov/mongodump"
+
+docker run -d --name mongodump_$CONTAINER_NAME -v $BACKUP_DIR:/backup -e 'CRON_SCHEDULE=* * * * *' --link $CONTAINER_NAME:mongo $DOCKER_NAME

--- a/install-backup.sh
+++ b/install-backup.sh
@@ -3,4 +3,4 @@ BACKUP_DIR=/var/backups/mongodb
 CONTAINER_NAME=$1
 DOCKER_NAME="istepanov/mongodump"
 
-docker run -d --name mongodump_$CONTAINER_NAME -v $BACKUP_DIR:/backup -e 'CRON_SCHEDULE=* * * * *' --link $CONTAINER_NAME:mongo $DOCKER_NAME
+docker run -d --name mongodump_$CONTAINER_NAME -v $BACKUP_DIR:/backup --link $CONTAINER_NAME:mongo $DOCKER_NAME

--- a/run-backup.sh
+++ b/run-backup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 CONTAINER_NAME=$1
+DOCKER_NAME="istepanov/mongodump"
 
-docker run --rm -v $DIR:/backup --link $CONTAINER_NAME:mongo mongobackup no-cron
+docker run --rm -v $DIR:/backup --link $CONTAINER_NAME:mongo $DOCKER_NAME no-cron

--- a/run-backup.sh
+++ b/run-backup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+CONTAINER_NAME=$1
+
+docker run --rm -v $DIR:/backup --link $CONTAINER_NAME:mongo mongobackup no-cron

--- a/run-backup.sh
+++ b/run-backup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+BACKUP_DIR=/var/backups/mongodb
 CONTAINER_NAME=$1
 DOCKER_NAME="istepanov/mongodump"
 
-docker run --rm -v $DIR:/backup --link $CONTAINER_NAME:mongo $DOCKER_NAME no-cron
+docker run --rm -v $BACKUP_DIR:/backup --link $CONTAINER_NAME:mongo $DOCKER_NAME no-cron

--- a/start.sh
+++ b/start.sh
@@ -9,6 +9,6 @@ CRON_SCHEDULE=${CRON_SCHEDULE:-0 1 * * *}
 if [[ "$1" == 'no-cron' ]]; then
     exec /backup.sh
 else
-    echo "$CRON_SCHEDULE /backup.sh" | crontab -
+    cp /crontab /etc/cron.d/mongobackup-cron
     exec cron -f
 fi


### PR DESCRIPTION
Had an error: 
assertion: 17369 Backing up users and roles is only supported for clusters with auth schema versions 1 or 3, found: 5
explanation can be found here: http://stackoverflow.com/questions/27664250/mongodump-assertion-17369

Changed Dockerfile to use last version of mongo (which I use in production in my project).

Also added a script for quick test of the docker container

Thanks for sharing your work! -)
