### PR TITLE
Upgrade to mongoDB 3.3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:3.0
+FROM mongo:3.3.6
 MAINTAINER Ilya Stepanov <dev@ilyastepanov.com>
 
 RUN apt-get update && \

--- a/backup.sh
+++ b/backup.sh
@@ -6,9 +6,10 @@ echo "Job started: $(date)"
 
 DATE=$(date +%Y%m%d_%H%M%S)
 FILE="/backup/backup-$DATE.tar.gz"
+OUTPUT="dump/"
 
-mongodump --quiet -h $MONGO_PORT_27017_TCP_ADDR -p $MONGO_PORT_27017_TCP_PORT
-tar -zcvf $FILE dump/
-rm -rf dump/
+mongodump --quiet --host $MONGODB_HOST:$MONGODB_PORT --out $OUTPUT
+tar -zcvf $FILE $OUTPUT
+rm -rf $OUTPUT
 
 echo "Job finished: $(date)"

--- a/start.sh
+++ b/start.sh
@@ -11,8 +11,8 @@ else
     if [[ ! -e "$LOGFIFO" ]]; then
         mkfifo "$LOGFIFO"
     fi
-    CRON_ENV="MONGO_PORT_27017_TCP_ADDR='$MONGO_PORT_27017_TCP_ADDR'"
-    CRON_ENV="$CRON_ENV\nMONGO_PORT_27017_TCP_PORT='$MONGO_PORT_27017_TCP_PORT'"
+    CRON_ENV="MONGODB_HOST='$MONGODB_HOST'"
+    CRON_ENV="$CRON_ENV\nMONGODB_PORT='$MONGODB_PORT'"
     echo -e "$CRON_ENV\n$CRON_SCHEDULE /backup.sh > $LOGFIFO 2>&1" | crontab -
     crontab -l
     cron


### PR DESCRIPTION
- Upgrade and readapt var env
- add out option for mongodump according to the documentation
- rename Host and Port variable to be more simple and generic avoiding the mention of '27017' according to the way that the user can used different one.
