### PR TITLE
Date as Env, Push Mongo 4.4, AWS Path

### DIFF
--- a/Dockerfile-4.4
+++ b/Dockerfile-4.4
@@ -1,4 +1,4 @@
-FROM mongo:4.4.1
+FROM mongo:4.4.5
 MAINTAINER Ilya Stepanov <dev@ilyastepanov.com>
 
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Docker image with `mongodump`, `cron` and AWS CLI to upload backups to AWS S3.
 | `TARGET_S3_FOLDER`      | Folder to upload backups. Leave it empty to disable upload to S3. | `''` |
 | `AWS_ACCESS_KEY_ID`     | AWS Access Key ID. Leave empty if you want to use AWS IAM Role instead. | `''` |
 | `AWS_SECRET_ACCESS_KEY` | AWS Access Key ID. Leave empty if you want to use AWS IAM Role instead. | `''` |
+| `TZ`                    | Timezone | `''` |
+| `DATE` | Override Date in generated Filename. Leave empty to use $(date +%Y%m%d_%H%M%S) | `''` |
 
 ### Examples
 

--- a/backup.sh
+++ b/backup.sh
@@ -4,7 +4,9 @@ set -eo pipefail
 
 echo "Job started: $(date)"
 
-DATE=$(date +%Y%m%d_%H%M%S)
+if [[ -z $DATE ]]; then
+    DATE=$(date +%Y%m%d_%H%M%S)
+fi
 
 if [[ -z "$TARGET_FOLDER" ]]; then
     # dump directly to AWS S3

--- a/backup.sh
+++ b/backup.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 echo "Job started: $(date)"
 
-if [[ -z $DATE ]]; then
+if [[ -z "$DATE" ]]; then
     DATE=$(date +%Y%m%d_%H%M%S)
 fi
 

--- a/backup.sh
+++ b/backup.sh
@@ -14,7 +14,7 @@ if [[ -z "$TARGET_FOLDER" ]]; then
         exit 1
     fi
 
-    mongodump --uri "$MONGO_URI" --gzip --archive | aws s3 cp - "${TARGET_S3_FOLDER%/}/backup-$DATE.tar.gz"
+    mongodump --uri "$MONGO_URI" --gzip --archive | /usr/local/bin/aws s3 cp - "${TARGET_S3_FOLDER%/}/backup-$DATE.tar.gz"
     echo "Mongo dump uploaded to $TARGET_S3_FOLDER"
 else
     # save dump locally (and optionally to AWS S3)


### PR DESCRIPTION
this makes it possible to override the Date-var from Env, so you can make it static in case of additional backup-solutions. 
